### PR TITLE
Upstream async get

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
       "name" : "Marc Brakken"
     }
   ],
-  "license" : "GPL-3.0"
-
+  "license" : "GPL-3.0",
+  "dependencies" : {
+    "through" : "2.3.8",
+    "through2" : "2.0.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "keywords" : [
     "filesystem",
     "deduplicate",
-    "http"
+    "http",
+    "rest"
   ],
   "author" : {
     "name" : "Jason Gullickson"
@@ -28,7 +29,6 @@
   ],
   "license" : "GPL-3.0",
   "dependencies" : {
-    "through" : "2.3.8",
-    "through2" : "2.0.1"
+    "through" : "2.3.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name" : "jsfs",
+  "version" : "0.4.0",
+  "description" : "deduplicating filesystem with a REST interface",
+  "main" : "server.js",
+  "files" : [
+    "server.js",
+    "config.ex",
+    "jlog.js"
+  ],
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/jjg/jsfs.git"
+  },
+  "homepage" : "https://github.com/jjg/jsfs",
+  "keywords" : [
+    "filesystem",
+    "deduplicate",
+    "http"
+  ],
+  "author" : {
+    "name" : "Jason Gullickson"
+  },
+  "contributors" : [
+    {
+      "name" : "Marc Brakken"
+    }
+  ],
+  "license" : "GPL-3.0"
+
+}

--- a/server.js
+++ b/server.js
@@ -15,8 +15,6 @@ var config  = require("./config.js");
 var log     = require("./jlog.js");
 var url     = require("url");
 var through = require("through");
-var through2 = require("through2");
-var stream  = require("stream");
 
 /**
 
@@ -499,12 +497,10 @@ http.createServer(function(req, res){
         }
 
         var create_decryptor = function create_decryptor(options){
-          // return options.encrypted ? crypto.createDecipher("aes-256-cbc", options.key) : new stream.PassThrough();
           return options.encrypted ? crypto.createDecipher("aes-256-cbc", options.key) : through();
         };
 
         var create_unzipper = function create_decryptor(compressed){
-          // return compressed ? zlib.createGunzip() : new stream.PassThrough();
           return compressed ? zlib.createGunzip() : through();
         };
 
@@ -546,18 +542,6 @@ http.createServer(function(req, res){
           var read_stream = fs.createReadStream(path);
           var decryptor   = create_decryptor({ encrypted : requested_file.encrypted, key : requested_file.access_key});
           var unzipper    = create_unzipper(try_compressed);
-
-          // unzipper.on("end", uz_on_end);
-          // function uz_on_end(){
-          //   unzipper.removeListener("end", uz_on_end);
-          //   // unzipper.unpipe(decryptor);
-          // }
-
-          // decryptor.on("end", dc_on_end);
-          // function dc_on_end(){
-          //   decryptor.removeListener("end", dc_on_end);
-          //   // decryptor.unpipe(res);
-          // }
 
           function on_error(){
             if (try_compressed) {


### PR DESCRIPTION
**Note: This is not yet tested in production / at scale, only locally, and I also need to test the encryption handling. Compression and missing-block hunting are both tested. I intend to test in a production context later today.**

The issue this is meant to resolve:

It takes a long time (> 10 seconds) to initially stream large files (~20 minute mp3s, vinyl rips, etc). This can cause some clients to time out. Subsequent requests return much faster.

On the server, when a new request comes in, the percentage of cpu time spent waiting increases substantially (20% total or more). Follow-up requests that return quickly don't cause wait time, probably because the file or its system metadata is still in a buffer / cache. I'm still learning how all that works.

This PR is intended as my first, application-level, attempt to reduce the response delay. My hope is that 1) by making the primary path async we eliminate blocking race conditions where `res.write` or something that follows in the response chain it doesn't become blocked by upstream synchronous reads (searching for misplaced blocks is still synchronous); and 2) by using a `readableStream` we can start delivering bits as soon as possible, not only after the entire block file is loaded into memory.

This PR *does* introduce a dependency, https://github.com/dominictarr/through, to provide a plain pipe in cases where the file is not compressed or encrypted. Initially I used a node-native `stream.PassThrough` pipe, but there was an intermittent issue where a request would not complete the last 100kB or so and the final `end` event would not trigger. It's possible I need to do something different to set up the `PassThrough`. The behavior appeared similar to when I initially did not set `{end: false}` on the response pipe, and the first `close` event issued from the `fs.readableStrream` closed down the entire pipe. I have not encountered these issues with `through()`, however.

Also, this branch currently emits `possible EventEmitter memory leak detected` warnings, I believe due to repeated `.pipe(res, {end: false})` calls while building out the full requested file. `.pipe()` adds event listeners to its destination, and *does* clean them up as it's unpiped as part of the internal management, but I hypothesize there's a race condition where, at least in my local environment, multiple listeners are added to `res` before early ones are removed.

The only way around this issue that I can think of is to forgo piping the data around and instead write `.on("data") ` handlers that handle cases appropriately (eg. `res.write(chunk)` if there's no encryption or compression, or build up a buffer to be processed in an `on("end")` handler if there is either encryption or compression.

I can update to a pipe-less version if preferred (I had initially written this without pipes, but wanted to see if I could get it working with them).

I also performed some linting.