### PR TITLE
Static access keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Keys are used to unlock all operations that can be performed on an object stored
 
 Tokens are more ephemeral, and any number of them can be generated to grant varying degrees of access to an object.  Token generation is described later.
 
+> If you want to limit the entire server to a fixed set of static `access_keys`, add the following parameter to `config.js`:
+> `STATIC_ACCESS_KEYS: ["foo", "bar"]`
+> Write requests for new files that do not include an `access_key` in this array will return `unauthorized`, as will any write request that includes no `access_key` or `access_token`.
+
 ### Parameters and Headers
 jsfs uses several parameters to control access to objects and how they are stored.  These values can also be supplied as request headers by adding a leading "x-" and changing "_" to "-" (`access_token` becomes `x-access-token`). Headers are preferred to querystring parameters because they are less likely to collide but both function the same. 
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,14 @@ Keys are used to unlock all operations that can be performed on an object stored
 
 Tokens are more ephemeral, and any number of them can be generated to grant varying degrees of access to an object.  Token generation is described later.
 
-> If you want to limit the entire server to a fixed set of static `access_keys`, add the following parameter to `config.js`:
-> `STATIC_ACCESS_KEYS: ["foo", "bar"]`
-> Write requests for new files that do not include an `access_key` in this array will return `unauthorized`, as will any write request that includes no `access_key` or `access_token`.
+#### Static access keys
+If you want to limit the entire server to a fixed set of static `access_keys`, add the following parameter to `config.js`:
+
+```js
+STATIC_ACCESS_KEYS: ["foo", "bar"]
+```
+
+Any write requests for new files that do not include an `access_key` in this array will return `unauthorized`, as will any write request that includes no `access_key` or `access_token`.
 
 ### Parameters and Headers
 jsfs uses several parameters to control access to objects and how they are stored.  These values can also be supplied as request headers by adding a leading "x-" and changing "_" to "-" (`access_token` becomes `x-access-token`). Headers are preferred to querystring parameters because they are less likely to collide but both function the same. 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Keys are used to unlock all operations that can be performed on an object stored
 Tokens are more ephemeral, and any number of them can be generated to grant varying degrees of access to an object.  Token generation is described later.
 
 #### Static access keys
-If you want to limit the entire server to a fixed set of static `access_keys`, add the following parameter to `config.js`:
+If you want to limit the entire server to a fixed set of static `access_keys`, add some keys to the `STATIC_ACCESS_KEYS` array in `config.js`:
 
 ```js
 STATIC_ACCESS_KEYS: ["foo", "bar"]

--- a/config.ex
+++ b/config.ex
@@ -7,5 +7,6 @@ module.exports = {
 	LOG_LEVEL: 0,
 	SERVER_PORT: 7302,
 	REQUEST_TIMEOUT: 30, // minutes
-	CONFIGURED_STORAGE: "fs"
+	CONFIGURED_STORAGE: "fs",
+  STATIC_ACCESS_KEYS: []
 };

--- a/config.ex
+++ b/config.ex
@@ -1,12 +1,12 @@
 module.exports = {
-	STORAGE_LOCATIONS:[
-		{"path":"./blocks1/"},
-		{"path":"./blocks2/"}
-	],
-	BLOCK_SIZE: 1048576,
-	LOG_LEVEL: 0,
-	SERVER_PORT: 7302,
-	REQUEST_TIMEOUT: 30, // minutes
-	CONFIGURED_STORAGE: "fs",
+  STORAGE_LOCATIONS:[
+    {"path":"./blocks1/"},
+    {"path":"./blocks2/"}
+  ],
+  BLOCK_SIZE: 1048576,
+  LOG_LEVEL: 0,
+  SERVER_PORT: 7302,
+  REQUEST_TIMEOUT: 30, // minutes
+  CONFIGURED_STORAGE: "fs",
   STATIC_ACCESS_KEYS: []
 };

--- a/server.js
+++ b/server.js
@@ -217,8 +217,7 @@ http.createServer(function(req, res){
         } else {
 
           // if static access keys are configured, require an access key or token
-          // TODO: DRY up these unauthorized responses.
-          // TODO: Test with existing files, access_tokens
+          // TODO: Maybe DRY up these unauthorized responses.
           if("STATIC_ACCESS_KEYS" in config && config.STATIC_ACCESS_KEYS.length > 0){
             if((!params.access_key || params.access_key.length < 1) && (!params.access_token || params.access_token.length < 1)) {
               log.message(log.WARN, "File update request unauthorized");

--- a/server.js
+++ b/server.js
@@ -215,6 +215,28 @@ http.createServer(function(req, res){
             return;
           }
         } else {
+
+          // if static access keys are configured, require an access key or token
+          // TODO: DRY up these unauthorized responses.
+          // TODO: Test with existing files, access_tokens
+          if(config.STATIC_ACCESS_KEYS.length > 0){
+            if((params.access_key.length < 1) && (params.access_token.length < 1)) {
+              log.message(log.WARN, "File update request unauthorized");
+              res.statusCode = 401;
+              res.end();
+              return;
+            }
+            // if an access_key was provided, check against the static keys
+            if(params.access_key.length > 0){
+              if(!config.STATIC_ACCESS_KEYS.includes(params.access_key)){
+                log.message(log.WARN, "File update request unauthorized");
+                res.statusCode = 401;
+                res.end();
+                return;
+              }
+            }
+          }
+
           log.message(log.DEBUG, "No existing file found, storing new file");
         }
 

--- a/server.js
+++ b/server.js
@@ -219,7 +219,7 @@ http.createServer(function(req, res){
           // if static access keys are configured, require an access key or token
           // TODO: DRY up these unauthorized responses.
           // TODO: Test with existing files, access_tokens
-          if(config.STATIC_ACCESS_KEYS.length > 0){
+          if("STATIC_ACCESS_KEYS" in config && config.STATIC_ACCESS_KEYS.length > 0){
             if((params.access_key.length < 1) && (params.access_token.length < 1)) {
               log.message(log.WARN, "File update request unauthorized");
               res.statusCode = 401;

--- a/server.js
+++ b/server.js
@@ -220,14 +220,14 @@ http.createServer(function(req, res){
           // TODO: DRY up these unauthorized responses.
           // TODO: Test with existing files, access_tokens
           if("STATIC_ACCESS_KEYS" in config && config.STATIC_ACCESS_KEYS.length > 0){
-            if((params.access_key.length < 1) && (params.access_token.length < 1)) {
+            if((!params.access_key || params.access_key.length < 1) && (!params.access_token || params.access_token.length < 1)) {
               log.message(log.WARN, "File update request unauthorized");
               res.statusCode = 401;
               res.end();
               return;
             }
             // if an access_key was provided, check against the static keys
-            if(params.access_key.length > 0){
+            if(params.access_key && params.access_key.length > 0){
               if(!config.STATIC_ACCESS_KEYS.includes(params.access_key)){
                 log.message(log.WARN, "File update request unauthorized");
                 res.statusCode = 401;


### PR DESCRIPTION
Implements #142 by returning `401` for writes (`POST`, `PUT`) when the config contains a populated `STATIC_ACCESS_KEYS` array and no `access_key` or `access_token` is specified.

For existing files, the regular authorization rules apply.